### PR TITLE
make parameters editable

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
             <script src="./scripts/addFeature.js"></script>
             <script src="./scripts/gcodeGenerator.js"></script>
             <div id="parametersMenuCard" class="menuCard" >
-                <div id="definedParamters" style="display: flex; flex-direction: column;"> </div>
+                <div id="definedParameters" style="display: flex; flex-direction: column;"> </div>
                 <div id="newParameter" style="display: flex; flex-direction: row;"> 
                     <input type="text" style="margin: 0;" id="parameterName" >
                     <input type="text" style="margin: 0;" id="parameterValue">

--- a/scripts/parameters.js
+++ b/scripts/parameters.js
@@ -1,51 +1,85 @@
-let definedParameters = {};
+let definedParameters = {}; // public
+let parameterObjects = []; // internal bookkeeping (private to file)
 
-const definedParametersDiv = document.getElementById("definedParamters");
+const definedParametersDiv = document.getElementById("definedParameters");
 
-document.getElementById("addParameter").addEventListener('click', () => addParameter(document.getElementById("parameterName"), document.getElementById("parameterValue")));
+document.getElementById("addParameter").addEventListener("click", () => {
+  const nameElem = document.getElementById("parameterName");
+  const valueElem = document.getElementById("parameterValue");
+  addParameter(nameElem.value, valueElem.value);
+  nameElem.value = "";
+  valueElem.value = "";
+});
 
-function addParameter(paraNameInput, paraValueInput) {
+const updateParamObject = (index, type) => (element) => {
+  const elementIdx = parameterObjects.findIndex((e) => e.index === index);
 
-    const paraName = paraNameInput.value;
-    const paraValue = paraValueInput.value;
-    if (paraName != "" && paraValue != "") {
-        definedParameters[paraName] = paraValue;
-        saveParameterseToCache();
-        updateDefinedParameters();
-    }
+  if (type === 'key') {
+    parameterObjects[elementIdx].key = element.target.value;
+  } else if (type === 'value') {
+    parameterObjects[elementIdx].val = element.target.value;
+  }
 
-    paraNameInput.value = "";
-    paraValueInput.value = "";
+  updateDefinedParameters();
+  saveParametersToCache();
+};
+
+function addParameter(paraName, paraValue) {
+  const uniqueIndex = Math.random();
+  if (paraName != "" && paraValue != "") {
+    parameterObjects.push({ key: paraName, val: paraValue, index: uniqueIndex});
+    updateDefinedParameters();
+    saveParametersToCache();
+  }
+
+  const newParameterElem = document.createElement("span");
+  const newParameterElemKey = document.createElement("input");
+  const newParameterElemValue = document.createElement("input");
+
+  newParameterElemKey.value = paraName;
+  newParameterElemKey.oninput = updateParamObject(uniqueIndex, 'key');
+  newParameterElemValue.value = paraValue;
+  newParameterElemValue.oninput = updateParamObject(uniqueIndex, 'value');
+
+  newParameterElem.appendChild(newParameterElemKey);
+  newParameterElem.appendChild(newParameterElemValue);
+
+  definedParametersDiv.appendChild(newParameterElem);
 }
 
+// derive definedParameters from parameterObjects
 function updateDefinedParameters() {
+  definedParameters = {};
 
-    const keys = Object.keys(definedParameters);
-
-    definedParametersDiv.innerHTML = "";
-    keys.forEach((key) => {
-        definedParametersDiv.innerHTML = definedParametersDiv.innerHTML + `<span style='margin-bottom:10px; margin-left:5px'>${key}:${definedParameters[key]}<span>`;
-    });
-
+  parameterObjects.forEach((element) => {
+    definedParameters[element.key] = element.val;
+  });
 }
 
 function loadParameterFromCache() {
-    const cachedParameters = localStorage.getItem("parameters");
+  const cachedParameters = localStorage.getItem("parameters");
+  let parsedParameters = {}
 
-    if (cachedParameters != null)
-        definedParameters = JSON.parse(cachedParameters);
+  if (cachedParameters != null) 
+    parsedParameters = JSON.parse(cachedParameters);
+
+  const keys = Object.keys(parsedParameters);
+  for (const key of keys) {
+    addParameter(key, parsedParameters[key]);
+  }
 }
 
-function saveParameterseToCache() {
-    localStorage.setItem("parameters", JSON.stringify(definedParameters));
+function saveParametersToCache() {
+  localStorage.setItem("parameters", JSON.stringify(definedParameters));
 }
 
 function resetParameters() {
-    definedParameters = {};
-    saveParameterseToCache();
-    updateDefinedParameters();
+  parameterObjects = [];
+  definedParameters = {};
+  definedParametersDiv.innerHTML = "";
+  saveParametersToCache();
 }
 
 loadParameterFromCache();
-saveParameterseToCache();
 updateDefinedParameters();
+saveParametersToCache();


### PR DESCRIPTION
Hi! thought I would suggest this change back upstream!

This small change lets me iterate faster by making the variables feature 'editable', only question I have is that there seems to be some parsing issues when it comes to certain parameters, like when I use a variable to replace a relative move like R10, I ideally want to be able to write it as R\`varname\` (with the value declared as `10`). but for now I have to write it as \`varname\` and declare the variable value as `R10` But seems like this isn't going to be straightforward.

![image](https://user-images.githubusercontent.com/819074/163378787-babfc396-4837-4061-ac1a-a6950aa61199.png)
